### PR TITLE
feat: Add manual backfill for syncing existing WorkOS users

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -33,17 +33,6 @@ type Options = {
   additionalEventTypes?: WorkOSEvent["event"][];
   actionSecret?: string;
   logLevel?: "DEBUG";
-  /**
-   * Initial range (in hours) to fetch events when no cursor exists.
-   * Defaults to 168 hours (7 days).
-   */
-  initialRangeHours?: number;
-  /**
-   * When enabled, creates a user in the database if a `user.updated` event
-   * is received but the user doesn't exist. This handles cases where a
-   * `user.created` event was missed.
-   */
-  createUserOnUpdate?: boolean;
 };
 type Config = SetRequired<Options, "clientId" | "apiKey" | "webhookSecret">;
 
@@ -248,8 +237,6 @@ export class AuthKit<DataModel extends GenericDataModel> {
             "updated_at" in event ? (event.updated_at as string) : undefined,
           eventTypes: this.config.additionalEventTypes,
           logLevel: this.config.logLevel,
-          initialRangeHours: this.config.initialRangeHours,
-          createUserOnUpdate: this.config.createUserOnUpdate,
         });
         return new Response("OK", { status: 200 });
       }),

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -72,7 +72,6 @@ export const updateEvents = internalAction({
     let rangeStart = nextCursor
       ? undefined
       : new Date(Date.now() - 1000 * 60 * 5).toISOString();
-
     do {
       const { data, listMetadata } = await workos.events.listEvents({
         events: eventTypes,

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -21,4 +21,9 @@ export default defineSchema({
     createdAt: v.string(),
     updatedAt: v.string(),
   }).index("id", ["id"]),
+  // Sync state for manual backfill
+  syncState: defineTable({
+    key: v.literal("lastCheckpointedEventId"),
+    value: v.string(),
+  }).index("key", ["key"]),
 });


### PR DESCRIPTION
## Problem

When starting a new Convex app against an existing WorkOS project, users created months ago won't trigger any webhooks (`user.created`, `user.updated`). This means historical users never get imported, even if the WorkOS project already contains them.

## Solution

Added a manual `backfillEvents` internal action that:

1. Fetches all events from WorkOS after the last checkpoint
2. Batch checks which events are missing using `_creationTime` range queries (efficient by induction)
3. Processes only missing events - skips duplicates
4. Updates checkpoint per batch - enables resume on failure

## New Functions

- `getLastCheckpointedEvent` (internalQuery) - Returns last checkpoint eventId + `_creationTime`
- `getMissingEventIds` (internalQuery) - Batch checks which event IDs are missing from DB
- `updateLastCheckpointedEventId` (internalMutation) - Upserts checkpoint in `syncState` table
- `backfillEvents` (internalAction) - Manual backfill - fetches & processes missing events

## Schema Changes

Added `syncState` table to track backfill progress:

```ts
syncState: defineTable({
  key: v.literal("lastCheckpointedEventId"),
  value: v.string(),
}).index("key", ["key"]),## Usage

await ctx.runAction(internal.lib.backfillEvents, {
  apiKey: "sk_...",
  logLevel: "DEBUG", // optional
}); // or, admin user can run this internal action manually in convex dashboard
```

## Why This Approach?
- **Explicit**: Manual invocation gives users full control over when backfill runs
- **Resumable**: Per-batch checkpointing means failures don't restart from zero
- **Efficient**: Checkpoint cursor avoids re-fetching all events on every run; batch queries instead of N individual checks per event
- **Safe**: By induction, events before checkpoint are guaranteed to exist, so we only query events after `_creationTime` in `getMissingEventIds` query.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.