### PR TITLE
Fixed webhook event validator

### DIFF
--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -98,6 +98,7 @@ export const processEvent = internalMutation({
       createdAt: v.string(),
       event: v.string(),
       data: v.record(v.string(), v.any()),
+      context: v.optional(v.record(v.string(), v.any())),
     }),
     logLevel: v.optional(v.literal("DEBUG")),
     onEventHandle: v.optional(v.string()),


### PR DESCRIPTION
<!-- Describe your PR here. -->
Fix for issue #4. Added an optional object on the event validator. WorkOS now sends context with at least the `user.created` and `user.updated` event, but this PR should work for any.

Example WorkOS `user.created` body:
```json
{
  "id": "event_01KESXQ24XXMRYQWSZS830JDMV",
  "data": {
    "id": "user_01KESXQ223VEKKXGHDC16XRJD3",
    "email": "johndoe@example.com",
    "locale": null,
    "object": "user",
    "metadata": {},
    "last_name": "Doe",
    "created_at": "2026-01-12T20:17:47.570Z",
    "first_name": "John",
    "updated_at": "2026-01-12T20:17:47.570Z",
    "external_id": null,
    "email_verified": false,
    "last_sign_in_at": null,
    "profile_picture_url": null
  },
  "event": "user.created",
  "context": {
    "client_id": "client_01KEP9J666ZK4M9WWHRCX22H03",
    "ajs_anonymous_id": "b12197b7-3a90-412b-8cd3-812f9f82ab28",
    "google_analytics_client_id": "1473627845.1768127156"
  },
  "created_at": "2026-01-12T20:17:47.677Z"
}
```
I would love to make the validator more resilient to changes by WorkOS but I don't know if there is a way in Convex to validate half an object and ignore any other keys.

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
