### PR TITLE
Add public query to get user by `externalId`

### DIFF
--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -213,3 +213,17 @@ export const getAuthUser = query({
     return user ? withoutSystemFields(user) : null;
   },
 });
+
+export const getAuthUserByExternalId = query({
+  args: {
+    externalId: v.string(),
+  },
+  returns: v.union(schema.tables.users.validator, v.null()),
+  handler: async (ctx, args) => {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("externalId", (q) => q.eq("externalId", args.externalId))
+      .unique();
+    return user ? withoutSystemFields(user) : null;
+  },
+});

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -23,5 +23,5 @@ export default defineSchema({
     locale: v.optional(v.union(v.null(), v.string())),
     createdAt: v.string(),
     updatedAt: v.string(),
-  }).index("id", ["id"]),
+  }).index("id", ["id"]).index("externalId", ["externalId"]),
 });


### PR DESCRIPTION
It's pretty simple, but here's what this PR adds:
- Add index for `externalId` on the `users` table
- Add the public query `getAuthUserByExternalId` to `lib.ts`

Closes #59 

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
