### PR TITLE
Allow WorkOS v10 user name field

### DIFF
--- a/src/component/_generated/component.ts
+++ b/src/component/_generated/component.ts
@@ -48,6 +48,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           lastSignInAt?: null | string;
           locale?: null | string;
           metadata: Record<string, any>;
+          name?: null | string;
           profilePictureUrl?: null | string;
           updatedAt: string;
         } | null,
@@ -68,6 +69,7 @@ export type ComponentApi<Name extends string | undefined = string | undefined> =
           lastSignInAt?: null | string;
           locale?: null | string;
           metadata: Record<string, any>;
+          name?: null | string;
           profilePictureUrl?: null | string;
           updatedAt: string;
         } | null,

--- a/src/component/backfill.test.ts
+++ b/src/component/backfill.test.ts
@@ -23,6 +23,7 @@ vi.mock("@workos-inc/node", () => {
 const defaultUser = {
   id: "user_01ABC",
   email: "alice@example.com",
+  name: "Alice Smith" as string | null,
   firstName: "Alice" as string | null,
   lastName: "Smith" as string | null,
   emailVerified: true,
@@ -87,6 +88,7 @@ describe("backfill", () => {
     });
     expect(dbUsers).toHaveLength(1);
     expect(dbUsers[0].id).toBe(user.id);
+    expect(dbUsers[0].name).toBe(user.name);
   });
 
   test("processUsersPage passes order asc to listUsers", async () => {

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -13,6 +13,7 @@ export default defineSchema({
   users: defineTable({
     id: v.string(),
     email: v.string(),
+    name: v.optional(v.union(v.null(), v.string())),
     firstName: v.optional(v.union(v.null(), v.string())),
     lastName: v.optional(v.union(v.null(), v.string())),
     emailVerified: v.boolean(),


### PR DESCRIPTION
## Summary
- Accept the optional `name` field now present on WorkOS user payloads from `@workos-inc/node` v10, matching the package's existing `^10.0.0` peer dependency support.
- Keep the Convex component's internal `users` schema aligned with the WorkOS v10 user shape: `name`, `firstName`, and `lastName` can all be present or nullable.
- Update the generated component API type and add regression coverage so backfilled users with `name` are stored successfully.

## Why
Without this, webhook or backfill user records emitted by WorkOS v10 can fail Convex validation with an extra-field error for `name`, even though v10 is accepted by the package peer dependency range.

## Testing
- `npm test`
- `npm run lint`
