### PR TITLE
fix: preserve signed WorkOS request bodies

### DIFF
--- a/src/client/index.test.ts
+++ b/src/client/index.test.ts
@@ -4,10 +4,24 @@ import { WorkOS } from "@workos-inc/node";
 import { AuthKit } from "./index.js";
 import type { ComponentApi } from "../component/_generated/component.js";
 
+const workosMocks = vi.hoisted(() => ({
+  constructAction: vi.fn(),
+  constructEvent: vi.fn(),
+  signResponse: vi.fn(),
+}));
+
 vi.mock("@workos-inc/node", () => {
   return {
     WorkOS: vi.fn().mockImplementation(function () {
-      return {};
+      return {
+        actions: {
+          constructAction: workosMocks.constructAction,
+          signResponse: workosMocks.signResponse,
+        },
+        webhooks: {
+          constructEvent: workosMocks.constructEvent,
+        },
+      };
     }),
   };
 });
@@ -106,4 +120,54 @@ describe("AuthKit.getAuthConfigProviders", () => {
       "https://api.workos.com/sso/jwks/client_test"
     );
   });
+});
+
+describe("AuthKit.registerRoutes", () => {
+  beforeEach(() => {
+    for (const [k, v] of Object.entries(requiredEnv)) {
+      process.env[k] = v;
+    }
+  });
+
+  afterEach(() => {
+    for (const k of Object.keys(requiredEnv)) {
+      delete process.env[k];
+    }
+    vi.clearAllMocks();
+  });
+
+  test.each([
+    ["/workos/webhook", workosMocks.constructEvent],
+    ["/workos/action", workosMocks.constructAction],
+  ] as const)(
+    "passes the exact raw body to %s verification",
+    async (path, verify) => {
+      const authKit = new AuthKit(fakeComponent, {
+        actionSecret: "action_secret",
+      });
+      const route = vi.fn();
+      authKit.registerRoutes({ route } as never);
+
+      const registeredRoute = route.mock.calls.find(
+        ([candidate]) => candidate.path === path
+      )?.[0];
+      expect(registeredRoute).toBeDefined();
+
+      const rawBody = '{\n  "value": "\\u003c"\n}';
+      const request = new Request(`https://example.com${path}`, {
+        method: "POST",
+        headers: { "workos-signature": "t=123,v1=abc" },
+        body: rawBody,
+      });
+      const stopAfterVerification = new Error("stop after verification");
+      verify.mockRejectedValueOnce(stopAfterVerification);
+
+      await expect(registeredRoute!.handler._handler({}, request)).rejects.toBe(
+        stopAfterVerification
+      );
+      expect(verify).toHaveBeenCalledWith(
+        expect.objectContaining({ payload: rawBody })
+      );
+    }
+  );
 });

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -23,8 +23,7 @@ import type { ComponentApi } from "../component/_generated/component.js";
 import { vEvent } from "../component/lib.js";
 
 type WorkOSResponsePayload =
-  | AuthenticationActionResponseData
-  | UserRegistrationActionResponseData;
+  AuthenticationActionResponseData | UserRegistrationActionResponseData;
 
 type Options = {
   authFunctions?: AuthFunctions;
@@ -249,7 +248,7 @@ export class AuthKit<DataModel extends GenericDataModel> {
           throw new Error("webhook secret is not set");
         }
         const event = await this.workos.webhooks.constructEvent({
-          payload: JSON.parse(payload),
+          payload,
           sigHeader: sigHeader,
           secret,
         });
@@ -282,7 +281,7 @@ export class AuthKit<DataModel extends GenericDataModel> {
           throw new Error("webhook secret is not set");
         }
         const action = await this.workos.actions.constructAction({
-          payload: JSON.parse(payload),
+          payload,
           sigHeader: sigHeader,
           secret,
         });


### PR DESCRIPTION
## Summary

- pass the exact `request.text()` value to WorkOS webhook signature verification
- do the same for AuthKit action signatures
- cover both routes with whitespace/escape-sensitive raw JSON

## Problem

`registerRoutes()` captures the raw request string, but then calls `JSON.parse(payload)` before handing it to `constructEvent()` / `constructAction()`.

The WorkOS Node SDK accepts strings directly. For object payloads it calls `JSON.stringify()` before computing the HMAC, so the current parse/stringify round trip can change whitespace and escaping. A valid signature over:

```json
{
  "value": "\u003c"
}
```

is then checked against a different byte/string representation such as `{"value":"<"}`.

WorkOS signs `<timestamp>.<exact UTF-8 request body>`, so verification must receive the original representation.

## Fix

Pass the already-captured string unchanged. Parsing remains owned by the WorkOS SDK after signature verification.

## Verification

- `npm test -- --run src/client/index.test.ts` — 7 passed, no type errors
- `npm run lint -- --no-cache` — passed
- `npx prettier --check src/client/index.ts src/client/index.test.ts` — passed after formatting

The regression test captures both registered HTTP handlers and proves each verifier receives JSON whose whitespace and `\u003c` escape are unchanged.
