### PR TITLE
Process all webhook events from the delivered payload

### DIFF
--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -135,6 +135,32 @@ describe("onWebhookEvent", () => {
     expect(dbEvents).toHaveLength(1);
   });
 
+  test("user.updated delivered before user.created upserts the user", async () => {
+    const t = initConvexTest();
+    const created = makeUser();
+    const updated = makeUser({
+      name: "Alice Jones",
+      lastName: "Jones",
+      updatedAt: "2024-01-02T00:00:00.000Z",
+    });
+
+    await t.mutation(api.lib.onWebhookEvent, {
+      apiKey: "sk_test_123",
+      event: makeEvent("user.updated", updated),
+    });
+    await t.mutation(api.lib.onWebhookEvent, {
+      apiKey: "sk_test_123",
+      event: makeEvent("user.created", created),
+    });
+
+    const dbUsers = await t.run(async (ctx) => {
+      return ctx.db.query("users").collect();
+    });
+    expect(dbUsers).toHaveLength(1);
+    expect(dbUsers[0].name).toBe("Alice Jones");
+    expect(dbUsers[0].updatedAt).toBe("2024-01-02T00:00:00.000Z");
+  });
+
   test("stale user.updated deliveries are skipped", async () => {
     const t = initConvexTest();
     const user = makeUser({

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -1,0 +1,163 @@
+/// <reference types="vite/client" />
+import { convexTest } from "convex-test";
+import { describe, test, expect } from "vitest";
+import { modules } from "./setup.test.js";
+import schema from "./schema.js";
+import workpool from "@convex-dev/workpool/test";
+import workflow from "@convex-dev/workflow/test";
+import { api } from "./_generated/api.js";
+
+/** Default test user values. */
+const defaultUser = {
+  id: "user_01ABC",
+  email: "alice@example.com",
+  name: "Alice Smith" as string | null,
+  firstName: "Alice" as string | null,
+  lastName: "Smith" as string | null,
+  emailVerified: true,
+  profilePictureUrl: null as string | null,
+  lastSignInAt: null as string | null,
+  externalId: null as string | null,
+  metadata: {} as Record<string, string>,
+  locale: null as string | null,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+/** Create a test user fixture. */
+function makeUser(overrides: Partial<typeof defaultUser> = {}) {
+  return { ...defaultUser, ...overrides };
+}
+
+/** Create a webhook event payload fixture. */
+function makeEvent(
+  event: string,
+  user: ReturnType<typeof makeUser>,
+  overrides: Partial<{ id: string; createdAt: string }> = {}
+) {
+  return {
+    id: overrides.id ?? `event_${event}`,
+    createdAt: overrides.createdAt ?? user.updatedAt,
+    event,
+    data: { object: "user", ...user },
+  };
+}
+
+/** Initialize a convex-test instance with sub-component registrations. */
+function initConvexTest() {
+  const t = convexTest(schema, modules);
+  workpool.register(t, "eventWorkpool");
+  workflow.register(t, "backfillWorkflow");
+  return t;
+}
+
+describe("onWebhookEvent", () => {
+  test("user.created inserts the user", async () => {
+    const t = initConvexTest();
+    const user = makeUser();
+
+    await t.mutation(api.lib.onWebhookEvent, {
+      apiKey: "sk_test_123",
+      event: makeEvent("user.created", user),
+    });
+
+    const dbUsers = await t.run(async (ctx) => {
+      return ctx.db.query("users").collect();
+    });
+    expect(dbUsers).toHaveLength(1);
+    expect(dbUsers[0].id).toBe(user.id);
+    expect(dbUsers[0].email).toBe(user.email);
+  });
+
+  test("user.updated patches the user from the delivered payload", async () => {
+    const t = initConvexTest();
+    const user = makeUser();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", user);
+    });
+
+    const updated = makeUser({
+      name: "Alice Jones",
+      lastName: "Jones",
+      updatedAt: "2024-01-02T00:00:00.000Z",
+    });
+    await t.mutation(api.lib.onWebhookEvent, {
+      apiKey: "sk_test_123",
+      event: makeEvent("user.updated", updated),
+    });
+
+    const dbUser = await t.run(async (ctx) => {
+      return ctx.db.query("users").unique();
+    });
+    expect(dbUser?.name).toBe("Alice Jones");
+    expect(dbUser?.updatedAt).toBe("2024-01-02T00:00:00.000Z");
+  });
+
+  test("user.deleted removes the user from the delivered payload", async () => {
+    const t = initConvexTest();
+    const user = makeUser();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", user);
+    });
+
+    await t.mutation(api.lib.onWebhookEvent, {
+      apiKey: "sk_test_123",
+      event: makeEvent("user.deleted", user),
+    });
+
+    const dbUsers = await t.run(async (ctx) => {
+      return ctx.db.query("users").collect();
+    });
+    expect(dbUsers).toHaveLength(0);
+  });
+
+  test("retried deliveries dedupe on eventId", async () => {
+    const t = initConvexTest();
+    const user = makeUser();
+    const event = makeEvent("user.created", user);
+
+    await t.mutation(api.lib.onWebhookEvent, {
+      apiKey: "sk_test_123",
+      event,
+    });
+    await t.mutation(api.lib.onWebhookEvent, {
+      apiKey: "sk_test_123",
+      event,
+    });
+
+    const { dbUsers, dbEvents } = await t.run(async (ctx) => {
+      return {
+        dbUsers: await ctx.db.query("users").collect(),
+        dbEvents: await ctx.db.query("events").collect(),
+      };
+    });
+    expect(dbUsers).toHaveLength(1);
+    expect(dbEvents).toHaveLength(1);
+  });
+
+  test("stale user.updated deliveries are skipped", async () => {
+    const t = initConvexTest();
+    const user = makeUser({
+      name: "Alice Jones",
+      updatedAt: "2024-01-02T00:00:00.000Z",
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("users", user);
+    });
+
+    const stale = makeUser({
+      name: "Alice Smith",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    });
+    await t.mutation(api.lib.onWebhookEvent, {
+      apiKey: "sk_test_123",
+      event: makeEvent("user.updated", stale),
+    });
+
+    const dbUser = await t.run(async (ctx) => {
+      return ctx.db.query("users").unique();
+    });
+    expect(dbUser?.name).toBe("Alice Jones");
+    expect(dbUser?.updatedAt).toBe("2024-01-02T00:00:00.000Z");
+  });
+});

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -73,8 +73,12 @@ async function processEventHandler(
         .withIndex("id", (q) => q.eq("id", data.id))
         .unique();
       if (!user) {
-        console.error("user not found", data.id);
-        return;
+        // The update may have been delivered before the create; the
+        // payload is the full user object, so insert it. The create
+        // no-ops on arrival via the existing-user guard above.
+        console.warn("user not found for update, inserting", data.id);
+        await ctx.db.insert("users", data);
+        break;
       }
       if (user.updatedAt >= data.updatedAt) {
         console.warn(`user already updated for event ${event.id}, skipping`);

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -115,20 +115,9 @@ export const onWebhookEvent = mutation({
   },
   returns: v.null(),
   handler: async (ctx, args) => {
-    const isCreateEvent = args.event.event.endsWith(".created");
-
-    if (isCreateEvent) {
-      // Process create events immediately
-      await processEventHandler(ctx, args);
-    } else {
-      // Enqueue update/delete events to workpool
-      await eventWorkpool.enqueueAction(ctx, internal.lib.updateEvents, {
-        apiKey: args.apiKey,
-        onEventHandle: args.onEventHandle,
-        eventTypes: args.eventTypes,
-        logLevel: args.logLevel,
-      });
-    }
+    // The payload is signature-verified and dedupes on eventId, so all
+    // event types can be processed inline.
+    await processEventHandler(ctx, args);
     return null;
   },
 });


### PR DESCRIPTION
## Summary

`onWebhookEvent` currently processes `.created` events inline but discards the delivered payload for update/delete events, instead enqueuing a workpool job that polls the WorkOS Events API with `after=<last stored eventId>`.

This can permanently lose events. The WorkOS Events API holds events back from ascending cursor reads for a few seconds after creation (so a later event ID can't advance a cursor past an older event that isn't visible yet). The sequence that drops an event:

1. WorkOS delivers e.g. `user.deleted`; the component returns 200 OK and discards the payload.
2. The enqueued poll runs ~1s later — the event is not yet visible to the Events API list, so nothing is returned.
3. A subsequent `.created` event is processed inline and inserted into the `events` table, advancing `getCursor` past the missed event.
4. All future polls use `after=<newer eventId>`, so the deletion is never fetched — the user is never deleted from the Convex `users` table.

We (WorkOS) confirmed a real occurrence of this with a customer: `user.deleted` was delivered successfully (HTTP 200, first attempt), but the Convex component never applied it.

## Fix

The webhook payload already contains the full, signature-verified event for every type — so process it directly, exactly like the existing `.created` path. The `eventId` dedupe guard in `processEventHandler` already makes this idempotent across webhook retries, and the `updatedAt` comparison guards out-of-order `user.updated` deliveries.

Since inline processing applies events in delivery order rather than Events API cursor order, `user.updated` now upserts when the user doesn't exist yet: webhook ordering isn't guaranteed and create-then-immediate-update is a common flow, so an update can arrive before its create. The updated payload is the full user object, so it's inserted directly, and the late-arriving create no-ops via the existing already-exists guard.

`updateEvents` is left in place (it's still a useful reconciliation primitive, e.g. wired to a cron), but is no longer the delivery path for updates/deletions.

## Alternatives considered

- **Delaying the enqueued poll past the visibility window.** Doesn't close the gap: the cursor is advanced client-side by any inline `.created` insert that lands during the delay, so the delayed poll still reads `after=<newer eventId>` and skips the older event. It also keys correctness to an undocumented API timing behavior and adds seconds of latency to deletions.
- **Keeping the poll but fixing the cursor.** Correct within the existing design, but requires advancing the cursor only from Events API reads (separate from the dedupe table), a catch-up loop that polls until it has read past the delivered event's ID, and coalescing that tracks a high-water mark — several new moving parts to re-fetch data the webhook already delivered verified.

One known edge is accepted: a `user.deleted` delivered before its `user.created` (user created and deleted within delivery jitter, deliveries reordered) leaves an inert row for a user who can't sign in; it's logged by the existing "user not found" warning and can be swept by a reconciliation pass.

## Test plan

- Added `src/component/lib.test.ts` covering `onWebhookEvent` for created/updated/deleted payloads, dedupe of retried deliveries, updated-before-created upsert, and the stale-update guard.
- `npm run build`, `npm run typecheck`, `npm run test` (24 passed), `npm run lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)